### PR TITLE
Use invariant culture for float parsing

### DIFF
--- a/vCardLib/Deserializers/Deserializer.cs
+++ b/vCardLib/Deserializers/Deserializer.cs
@@ -68,7 +68,7 @@ namespace vCardLib.Deserializers
                 throw new InvalidOperationException("details do not contain a specification for 'Version'.");
             }
 
-            var version = float.Parse(versionString.Replace("VERSION:", "").Trim());
+            var version = float.Parse(versionString.Replace("VERSION:", "").Trim(), CultureInfo.InvariantCulture);
             vCard vcard = null;
             if (version.Equals(2f) || version.Equals(2.1f))
             {


### PR DESCRIPTION
### PR Type _e.g fix, feature, chore etc_:
fix

### What does this PR do:
Resolves a bug where the decimal separator for some locales is "," instead of ".".

### Notes (if any):
