### PR TITLE
Issue with multi-line encoded pictures

### DIFF
--- a/vCardLib/Deserializers/v3Deserializer.cs
+++ b/vCardLib/Deserializers/v3Deserializer.cs
@@ -509,13 +509,9 @@ namespace vCardLib.Deserializers
                         var photoStrIndex = Array.IndexOf(contactDetails, photoStr);
                         while (true)
                         {
-                            if (photoStrIndex < contactDetails.Length)
+                            if (++photoStrIndex < contactDetails.Length && contactDetails[photoStrIndex].StartsWith("PHOTO;"))
                             {
                                 photoString += contactDetails[photoStrIndex];
-                                photoStrIndex++;
-                                if (photoStrIndex < contactDetails.Length &&
-                                    contactDetails[photoStrIndex].StartsWith("PHOTO;"))
-                                    break;
                             }
                             else
                             {


### PR DESCRIPTION
Sorry I don't have unit-tests associated, but currently when photos are multi-line, the first line is seen twice in the calculated photoString.

### PR Type _e.g fix, feature, chore etc_:

### What does this PR do:

### Notes (if any):
