### PR TITLE
Add support for custom telephone types

### DIFF
--- a/vCardLib.Tests/SerializerTests.cs
+++ b/vCardLib.Tests/SerializerTests.cs
@@ -90,6 +90,86 @@ namespace vCardLib.Tests
         }
 
         [Test]
+        public void V2CardShouldSerializeCustomTelephoneType()
+        {
+            var card = new vCard
+            {
+                Version = vCardVersion.V2,
+                Revision = new DateTime(2022, 01, 01),
+                FamilyName = "Card1",
+                FormattedName = "Card1",
+                PhoneNumbers = new List<TelephoneNumber>
+                {
+                    new TelephoneNumber
+                    {
+                        Type = TelephoneNumberType.Custom,
+                        CustomTypeName = "CUSTOM,VALUE",
+                        Value = "+1 234",
+                    },
+                    new TelephoneNumber
+                    {
+                        Type = TelephoneNumberType.Custom,
+                        CustomTypeName = "CUSTOM1",
+                        Value = "+1 234",
+                    }
+                }
+            };
+            var data = Serializer.Serialize(card);
+
+            // we need to use Environment.NewLine to pass unit-tests also in Unix environments. VS hardcodes \n\r due to Windows newline.
+            Assert.AreEqual(data, "BEGIN:VCARD" + Environment.NewLine +
+                                  "VERSION:2.1" + Environment.NewLine +
+                                  "REV:20220101T000000Z" + Environment.NewLine +
+                                  "N:Card1;;;;" + Environment.NewLine +
+                                  "FN:Card1" + Environment.NewLine +
+                                  "KIND:Individual" + Environment.NewLine +
+                                  "GENDER:None" + Environment.NewLine +
+                                  "TEL;TYPE=\"CUSTOM,VALUE\":+1 234" + Environment.NewLine +
+                                  "TEL;TYPE=\"CUSTOM1\":+1 234" + Environment.NewLine +
+                                  "END:VCARD");
+        }
+
+        [Test]
+        public void V3CardShouldSerializeCustomTelephoneType()
+        {
+            var card = new vCard
+                {
+                    Version = vCardVersion.V3,
+                    Revision = new DateTime(2022,01,01),
+                    FamilyName = "Card1",
+                    FormattedName = "Card1",
+                    PhoneNumbers = new List<TelephoneNumber>
+                    {
+                        new TelephoneNumber
+                        {
+                            Type = TelephoneNumberType.Custom,
+                            CustomTypeName = "CUSTOM,VALUE",
+                            Value = "+1 234",
+                        },
+                        new TelephoneNumber
+                        {
+                            Type = TelephoneNumberType.Custom,
+                            CustomTypeName = "CUSTOM1",
+                            Value = "+1 234",
+                        }
+                    }
+                };
+            var data = Serializer.Serialize(card);
+
+            // we need to use Environment.NewLine to pass unit-tests also in Unix environments. VS hardcodes \n\r due to Windows newline.
+            Assert.AreEqual(data, "BEGIN:VCARD" + Environment.NewLine +
+                                  "VERSION:3.0" + Environment.NewLine +
+                                  "REV:20220101T000000Z" + Environment.NewLine +
+                                  "N:Card1;;;;" + Environment.NewLine +
+                                  "FN:Card1" + Environment.NewLine +
+                                  "KIND:Individual" + Environment.NewLine +
+                                  "GENDER:None" + Environment.NewLine +
+                                  "TEL;TYPE=\"CUSTOM,VALUE\":+1 234" + Environment.NewLine +
+                                  "TEL;TYPE=\"CUSTOM1\":+1 234" + Environment.NewLine +
+                                  "END:VCARD");
+        }
+
+        [Test]
         public void ShouldThrowWithV4Card()
         {
             var card = new vCard

--- a/vCardLib/Enums/TelephoneNumberType.cs
+++ b/vCardLib/Enums/TelephoneNumberType.cs
@@ -38,6 +38,8 @@ namespace vCardLib.Enums
 
         ISDN = 8192,
         
-        Pref = 16384
+        Pref = 16384,
+
+        Custom = int.MaxValue,
     }
 }

--- a/vCardLib/Models/TelephoneNumber.cs
+++ b/vCardLib/Models/TelephoneNumber.cs
@@ -23,6 +23,11 @@ namespace vCardLib.Models
         public TelephoneNumberType Type { get; set; }
 
         /// <summary>
+        /// The telephone number extension
+        /// </summary>
+        public string CustomTypeName { get; set; }
+
+        /// <summary>
         /// Indicates the telephone numbers preference level (lower values mean a higher preference)
         /// </summary>
         public int? Preference { get; set; }

--- a/vCardLib/Serializers/v2Serializer.cs
+++ b/vCardLib/Serializers/v2Serializer.cs
@@ -28,6 +28,9 @@ namespace vCardLib.Serializers
                     case TelephoneNumberType.MainNumber:
                         stringBuilder.AppendLine("TEL;MAIN-NUMBER:" + phoneNumber.Value);
                         break;
+                    case TelephoneNumberType.Custom:
+                        stringBuilder.AppendLine($"TEL;TYPE=\"{phoneNumber.CustomTypeName}\":" + phoneNumber.Value);
+                        break;
                     default:
                         stringBuilder.AppendLine("TEL;" + phoneNumber.Type.ToString().ToUpper() + ":" + phoneNumber.Value);
                         break;

--- a/vCardLib/Serializers/v3Serializer.cs
+++ b/vCardLib/Serializers/v3Serializer.cs
@@ -28,6 +28,9 @@ namespace vCardLib.Serializers
                     case TelephoneNumberType.MainNumber:
                         stringBuilder.AppendLine("TEL;TYPE=MAIN-NUMBER:" + phoneNumber.Value);
                         break;
+                    case TelephoneNumberType.Custom:
+                        stringBuilder.AppendLine($"TEL;TYPE=\"{phoneNumber.CustomTypeName}\":" + phoneNumber.Value);
+                        break;
                     default:
                         stringBuilder.AppendLine("TEL;TYPE=" + phoneNumber.Type.ToString().ToUpper() + ":" +
                                                  phoneNumber.Value);


### PR DESCRIPTION
### PR Type: Feature

### What does this PR do:
Add support for custom telephone types, as from RFC: (https://datatracker.ietf.org/doc/html/rfc6350#section-6.1.4), see pages 34/35.

### Notes (if any):
Tested with Android Galaxy phone