### PR TITLE
Escape structured and list fields (N, ORG, ADR, CATEGORIES, LABEL) on v3/v4 round trips

### DIFF
--- a/src/vCardLib.Tests/Serialization/StructuredFieldEscapingRoundTripTests.cs
+++ b/src/vCardLib.Tests/Serialization/StructuredFieldEscapingRoundTripTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+using vCardLib.Deserialization;
+using vCardLib.Deserialization.FieldDeserializers;
+using vCardLib.Deserialization.Interfaces;
+using vCardLib.Enums;
+using vCardLib.Models;
+using vCardLib.Serialization;
+using vCardLib.Serialization.FieldSerializers;
+using vCardLib.Serialization.Interfaces;
+
+namespace vCardLib.Tests.Serialization;
+
+// The structured (N, ORG, ADR) and list (CATEGORIES) fields must survive a public
+// Serialize -> Deserialize round trip when their components contain the vCard delimiters
+// or a backslash. Covers the v3/v4 codec added here; v2.1 (no escaping) is asserted separately.
+[TestFixture]
+public class StructuredFieldEscapingRoundTripTests
+{
+    private static vCard RoundTrip(vCard card, vCardVersion version)
+    {
+        var text = vCardSerializer.Serialize(card, version);
+        return vCardDeserializer.FromContent(text).First();
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Categories_WithDelimitersAndBackslash_RoundTrips(vCardVersion version)
+    {
+        var input = new List<string> { "Food, Inc.", "R&D; Legal", @"C:\share", "plain" };
+        var card = new vCard(version) { FormattedName = "X", Categories = input };
+
+        var result = RoundTrip(card, version).Categories;
+
+        Console.WriteLine($"in=[{string.Join("|", input)}] out=[{string.Join("|", result)}]");
+        result.ShouldBe(input);
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Organization_WithSemicolonCommaAndBackslash_RoundTrips(vCardVersion version)
+    {
+        var org = new Organization("Ben & Jerry's; Homemade, Inc.", @"C:\temp Unit", @"Trailing\");
+        var card = new vCard(version) { FormattedName = "X", Organization = org };
+
+        var result = RoundTrip(card, version).Organization;
+
+        Console.WriteLine($"in=[{org.Name}|{org.PrimaryUnit}|{org.SecondaryUnit}] " +
+                          $"out=[{result?.Name}|{result?.PrimaryUnit}|{result?.SecondaryUnit}]");
+        result.ShouldNotBeNull();
+        result.Value.Name.ShouldBe(org.Name);
+        result.Value.PrimaryUnit.ShouldBe(org.PrimaryUnit);
+        result.Value.SecondaryUnit.ShouldBe(org.SecondaryUnit);
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Name_ComponentWithSemicolonAndComma_RoundTrips(vCardVersion version)
+    {
+        var name = new Name("Fam;ily,Name", "Giv\\en", "Add", "Mr.", "Esq.");
+        var card = new vCard(version) { FormattedName = "X", Name = name };
+
+        var result = RoundTrip(card, version).Name;
+
+        Console.WriteLine($"in=[{name.FamilyName}] out=[{result?.FamilyName}] given=[{result?.GivenName}]");
+        result.ShouldNotBeNull();
+        result.Value.FamilyName.ShouldBe(name.FamilyName);
+        result.Value.GivenName.ShouldBe(name.GivenName);
+        result.Value.AdditionalNames.ShouldBe(name.AdditionalNames);
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Address_ComponentWithSemicolonCommaAndBackslash_RoundTrips(vCardVersion version)
+    {
+        var address = new Address
+        {
+            StreetAddress = @"12;3 Main, St\ Back",
+            CityOrLocality = "Any;town",
+            StateOrProvinceOrRegion = "ST",
+            PostalOrZipCode = "12345",
+            Country = "USA"
+        };
+        var card = new vCard(version) { FormattedName = "X", Addresses = new List<Address> { address } };
+
+        var result = RoundTrip(card, version).Addresses.First();
+
+        Console.WriteLine($"in=[{address.StreetAddress}] out=[{result.StreetAddress}] city=[{result.CityOrLocality}]");
+        result.StreetAddress.ShouldBe(address.StreetAddress);
+        result.CityOrLocality.ShouldBe(address.CityOrLocality);
+        result.Country.ShouldBe(address.Country);
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Organization_PlausibleWindowsPath_IsNotRegexUnescaped(vCardVersion version)
+    {
+        // Regex.Unescape used to decode \t here, turning C:\temp into C:<TAB>emp.
+        var org = new Organization(@"C:\temp Corp", null, null);
+        var card = new vCard(version) { FormattedName = "X", Organization = org };
+
+        var result = RoundTrip(card, version).Organization;
+
+        result.ShouldNotBeNull();
+        result.Value.Name.ShouldBe(@"C:\temp Corp");
+        result.Value.Name.ShouldNotContain("\t");
+    }
+
+    [TestCase(vCardVersion.v3)]
+    [TestCase(vCardVersion.v4)]
+    public void Categories_WithNewline_RoundTrips(vCardVersion version)
+    {
+        var value = "Line one" + Environment.NewLine + "Line two";
+        var card = new vCard(version) { FormattedName = "X", Categories = new List<string> { value } };
+
+        var result = RoundTrip(card, version).Categories;
+
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(value);
+    }
+
+    // --- Escape-aware split truth table (deserializer level) ---
+
+    [Test]
+    public void OrgSplit_UnescapedSemicolon_SplitsComponents()
+    {
+        var result = ((IV3FieldDeserializer<Organization?>)new OrganizationFieldDeserializer()).Read("ORG:a;b");
+        result!.Value.Name.ShouldBe("a");
+        result.Value.PrimaryUnit.ShouldBe("b");
+    }
+
+    [Test]
+    public void OrgSplit_EscapedSemicolon_IsOneLiteralComponent()
+    {
+        var result = ((IV3FieldDeserializer<Organization?>)new OrganizationFieldDeserializer()).Read(@"ORG:a\;b");
+        result!.Value.Name.ShouldBe("a;b");
+        result.Value.PrimaryUnit.ShouldBeNull();
+    }
+
+    [Test]
+    public void OrgSplit_EscapedBackslashThenSemicolon_SplitsAfterLiteralBackslash()
+    {
+        // \\ ; -> escaped backslash followed by a structural separator.
+        var result = ((IV3FieldDeserializer<Organization?>)new OrganizationFieldDeserializer()).Read(@"ORG:a\\;b");
+        result!.Value.Name.ShouldBe(@"a\");
+        result.Value.PrimaryUnit.ShouldBe("b");
+    }
+
+    [Test]
+    public void CategoriesSplit_EscapedComma_IsOneValue()
+    {
+        var result = new CategoriesFieldDeserializer().Read(@"CATEGORIES:a\,b,c");
+        result.ShouldBe(new List<string> { "a,b", "c" });
+    }
+
+    // --- Lenient decode of loose input: undefined escapes keep the backslash (RFC 6350 3.4).
+    //     Regex.Unescape used to apply .NET regex grammar here (\t -> TAB, trailing \ dropped).
+
+    [Test]
+    public void OrgDecode_RawWindowsPath_KeepsBackslashNotTab()
+    {
+        var result = ((IV3FieldDeserializer<Organization?>)new OrganizationFieldDeserializer()).Read(@"ORG:C:\temp");
+        result!.Value.Name.ShouldBe(@"C:\temp");
+        result.Value.Name.ShouldNotContain("\t");
+    }
+
+    [Test]
+    public void OrgDecode_TrailingBackslash_IsPreserved()
+    {
+        var result = ((IV3FieldDeserializer<Organization?>)new OrganizationFieldDeserializer()).Read(@"ORG:Acme\");
+        result!.Value.Name.ShouldBe(@"Acme\");
+    }
+
+    // --- LABEL codec (Regex.Unescape misuse removed) ---
+
+    [Test]
+    public void Label_WindowsPath_UnitRoundTrips()
+    {
+        var label = new Label(@"C:\temp\report;final,v2", AddressType.Home);
+        var line = ((IV3FieldSerializer<Label>)new LabelFieldSerializer()).Write(label)!;
+        var result = new LabelFieldDeserializer().Read(line);
+
+        Console.WriteLine($"line=[{line}] in=[{label.Text}] out=[{result.Text}]");
+        result.Text.ShouldBe(label.Text);
+        result.Text.ShouldNotContain("\t");
+        result.Type.ShouldBe(AddressType.Home);
+    }
+
+    // --- No regression ---
+
+    [Test]
+    public void PlainValues_SerializeWithoutEscaping()
+    {
+        var card = new vCard(vCardVersion.v3)
+        {
+            FormattedName = "X",
+            Name = new Name("Doe", "John", "Middle", "Mr.", "Esq."),
+            Organization = new Organization("ABC Inc", "Sales", null),
+            Categories = new List<string> { "INTERNET", "IETF" }
+        };
+
+        var text = vCardSerializer.Serialize(card, vCardVersion.v3);
+
+        text.ShouldContain("N:Doe;John;Middle;Mr.;Esq.");
+        text.ShouldContain("ORG:ABC Inc;Sales");
+        text.ShouldContain("CATEGORIES:INTERNET,IETF");
+        text.ShouldNotContain(@"\");
+    }
+
+    [Test]
+    public void V2_DoesNotBackslashEscape()
+    {
+        var card = new vCard(vCardVersion.v2)
+        {
+            FormattedName = "X",
+            Organization = new Organization("A; B, C", null, null)
+        };
+
+        var text = vCardSerializer.Serialize(card, vCardVersion.v2);
+
+        text.ShouldContain("ORG:A; B, C");
+        text.ShouldNotContain(@"\;");
+        text.ShouldNotContain(@"\,");
+    }
+}

--- a/src/vCardLib/Deserialization/FieldDeserializers/AddressFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/AddressFieldDeserializer.cs
@@ -13,7 +13,12 @@ internal sealed class AddressFieldDeserializer : IV2FieldDeserializer<Address>,
 {
     public static string FieldKey => "ADR";
 
-    public Address Read(string input)
+    // v2.1 has no backslash escaping, so split on the raw delimiter.
+    Address IV2FieldDeserializer<Address>.Read(string input) => Parse(input, unescape: false);
+
+    public Address Read(string input) => Parse(input, unescape: true);
+
+    private static Address Parse(string input, bool unescape)
     {
         var (parameters, value) = DataSplitHelpers.SplitLine(FieldKey, input);
 
@@ -46,11 +51,14 @@ internal sealed class AddressFieldDeserializer : IV2FieldDeserializer<Address>,
 
         if (isQuotedPrintable) value = SharedParsers.DecodeQuotedPrintable(value);
 
-        var values = value.Split(FieldKeyConstants.MetadataDelimiter);
+        var values = unescape
+            ? ValueUnescaper.SplitUnescaped(value, FieldKeyConstants.MetadataDelimiter)
+            : value.Split(FieldKeyConstants.MetadataDelimiter);
         if (values.Length != 7)
             throw new Exception("Address parts incomplete");
 
-        return new Address(values[0], values[1], values[2], values[3], values[4], values[5], values[6], type, label,
-            geo);
+        string V(int index) => unescape ? ValueUnescaper.Unescape(values[index]) : values[index];
+
+        return new Address(V(0), V(1), V(2), V(3), V(4), V(5), V(6), type, label, geo);
     }
 }

--- a/src/vCardLib/Deserialization/FieldDeserializers/CategoriesFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/CategoriesFieldDeserializer.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using vCardLib.Constants;
 using vCardLib.Deserialization.Interfaces;
+using vCardLib.Deserialization.Utilities;
 
 namespace vCardLib.Deserialization.FieldDeserializers;
 
@@ -10,7 +11,12 @@ internal sealed class CategoriesFieldDeserializer : IV2FieldDeserializer<List<st
 {
     public static string FieldKey => "CATEGORIES";
 
-    public List<string> Read(string input)
+    // v2.1 has no backslash escaping, so split on the raw delimiter.
+    List<string> IV2FieldDeserializer<List<string>>.Read(string input) => Parse(input, unescape: false);
+
+    public List<string> Read(string input) => Parse(input, unescape: true);
+
+    private static List<string> Parse(string input, bool unescape)
     {
         var colonIndex = input.IndexOf(':');
         var value = colonIndex >= 0 ? input.Substring(colonIndex + 1) : input;
@@ -18,8 +24,12 @@ internal sealed class CategoriesFieldDeserializer : IV2FieldDeserializer<List<st
         if (string.IsNullOrWhiteSpace(value))
             return [];
 
-        return value.Split(FieldKeyConstants.ConcatenationDelimiter)
-            .Select(x => x.Trim())
+        var parts = unescape
+            ? ValueUnescaper.SplitUnescaped(value, FieldKeyConstants.ConcatenationDelimiter)
+            : value.Split(FieldKeyConstants.ConcatenationDelimiter);
+
+        return parts
+            .Select(x => (unescape ? ValueUnescaper.Unescape(x) : x).Trim())
             .ToList();
     }
 }

--- a/src/vCardLib/Deserialization/FieldDeserializers/LabelFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/LabelFieldDeserializer.cs
@@ -1,4 +1,3 @@
-﻿using System.Text.RegularExpressions;
 using vCardLib.Constants;
 using vCardLib.Deserialization.Interfaces;
 using vCardLib.Deserialization.Utilities;
@@ -13,12 +12,20 @@ internal sealed class LabelFieldDeserializer : IV2FieldDeserializer<Label>, IV3F
 {
     public static string FieldKey => "LABEL";
 
-    public Label Read(string input)
+    // v2.1 has no backslash escaping, so keep the text verbatim.
+    Label IV2FieldDeserializer<Label>.Read(string input) => Parse(input, unescape: false);
+
+    public Label Read(string input) => Parse(input, unescape: true);
+
+    Label? IV4FieldDeserializer<Label?>.Read(string input) => null;
+
+    private static Label Parse(string input, bool unescape)
     {
         var (metadata, value) = DataSplitHelpers.SplitLine(FieldKey, input);
+        var text = unescape ? ValueUnescaper.Unescape(value) : value;
 
         if (metadata.Length == 0)
-            return new Label(Regex.Unescape(value));
+            return new Label(text);
 
         AddressType? type = null;
 
@@ -43,8 +50,6 @@ internal sealed class LabelFieldDeserializer : IV2FieldDeserializer<Label>, IV3F
             }
         }
 
-        return new Label(Regex.Unescape(value), type);
+        return new Label(text, type);
     }
-
-    Label? IV4FieldDeserializer<Label?>.Read(string input) => null;
 }

--- a/src/vCardLib/Deserialization/FieldDeserializers/NameFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/NameFieldDeserializer.cs
@@ -1,5 +1,6 @@
-﻿using vCardLib.Constants;
+using vCardLib.Constants;
 using vCardLib.Deserialization.Interfaces;
+using vCardLib.Deserialization.Utilities;
 using vCardLib.Models;
 
 namespace vCardLib.Deserialization.FieldDeserializers;
@@ -9,7 +10,12 @@ internal sealed class NameFieldDeserializer : IV2FieldDeserializer<Name>, IV3Fie
 {
     public static string FieldKey => "N";
 
-    public Name Read(string input)
+    // v2.1 has no backslash escaping, so split on the raw delimiter.
+    Name IV2FieldDeserializer<Name>.Read(string input) => Parse(input, unescape: false);
+
+    public Name Read(string input) => Parse(input, unescape: true);
+
+    private static Name Parse(string input, bool unescape)
     {
         var separatorIndex = input.IndexOf(FieldKeyConstants.SectionDelimiter);
         var value = input.Substring(separatorIndex + 1).Trim();
@@ -19,23 +25,27 @@ internal sealed class NameFieldDeserializer : IV2FieldDeserializer<Name>, IV3Fie
             honorificPrefix = null,
             honorificSuffix = null;
 
-        var parts = value.Split(FieldKeyConstants.MetadataDelimiter);
-        var partsLength = parts.Length;
+        var parts = unescape
+            ? ValueUnescaper.SplitUnescaped(value, FieldKeyConstants.MetadataDelimiter)
+            : value.Split(FieldKeyConstants.MetadataDelimiter);
 
-        if (partsLength > 0)
-            familyName = parts[0];
+        string? Component(int index) =>
+            unescape ? ValueUnescaper.Unescape(parts[index]) : parts[index];
 
-        if (partsLength > 1)
-            givenName = parts[1];
+        if (parts.Length > 0)
+            familyName = Component(0);
 
-        if (partsLength > 2)
-            additionalNames = parts[2];
+        if (parts.Length > 1)
+            givenName = Component(1);
 
-        if (partsLength > 3)
-            honorificPrefix = parts[3];
+        if (parts.Length > 2)
+            additionalNames = Component(2);
 
-        if (partsLength > 4)
-            honorificSuffix = parts[4];
+        if (parts.Length > 3)
+            honorificPrefix = Component(3);
+
+        if (parts.Length > 4)
+            honorificSuffix = Component(4);
 
         return new Name(familyName, givenName, additionalNames, honorificPrefix, honorificSuffix);
     }

--- a/src/vCardLib/Deserialization/FieldDeserializers/OrganizationFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/OrganizationFieldDeserializer.cs
@@ -1,6 +1,6 @@
-﻿using System.Text.RegularExpressions;
 using vCardLib.Constants;
 using vCardLib.Deserialization.Interfaces;
+using vCardLib.Deserialization.Utilities;
 using vCardLib.Models;
 
 namespace vCardLib.Deserialization.FieldDeserializers;
@@ -10,27 +10,28 @@ internal sealed class OrganizationFieldDeserializer : IV2FieldDeserializer<Organ
 {
     public static string FieldKey => "ORG";
 
-    public Organization? Read(string input)
+    // v2.1 has no backslash escaping, so split on the raw delimiter.
+    Organization? IV2FieldDeserializer<Organization?>.Read(string input) => Parse(input, unescape: false);
+
+    public Organization? Read(string input) => Parse(input, unescape: true);
+
+    private static Organization? Parse(string input, bool unescape)
     {
         var colonIndex = input.IndexOf(':');
         var value = colonIndex >= 0 ? input.Substring(colonIndex + 1).Trim() : input.Trim();
-        string? orgName = null,
-            orgUnitOne = null,
-            orgUnitTwo = null;
 
-        var parts = value.Split(FieldKeyConstants.MetadataDelimiter);
-        var partsLength = parts.Length;
+        var parts = unescape
+            ? ValueUnescaper.SplitUnescaped(value, FieldKeyConstants.MetadataDelimiter)
+            : value.Split(FieldKeyConstants.MetadataDelimiter);
 
-        if (partsLength == 0)
+        if (parts.Length == 0)
             return null;
 
-        orgName = Regex.Unescape(parts[0]);
+        string Component(int index) => unescape ? ValueUnescaper.Unescape(parts[index]) : parts[index];
 
-        if (partsLength > 1)
-            orgUnitOne = parts[1];
-
-        if (partsLength > 2)
-            orgUnitTwo = parts[2];
+        var orgName = Component(0);
+        var orgUnitOne = parts.Length > 1 ? Component(1) : null;
+        var orgUnitTwo = parts.Length > 2 ? Component(2) : null;
 
         return new Organization(orgName, orgUnitOne, orgUnitTwo);
     }

--- a/src/vCardLib/Deserialization/FieldDeserializers/TextFieldDeserializer.cs
+++ b/src/vCardLib/Deserialization/FieldDeserializers/TextFieldDeserializer.cs
@@ -45,50 +45,6 @@ internal abstract class TextFieldDeserializer : IV2FieldDeserializer<string>, IV
 
         if (isQuotedPrintable) value = SharedParsers.DecodeQuotedPrintable(value);
 
-        return ParseValue(value, handleNewlines: true);
-    }
-
-    private static string ParseValue(string source, bool handleNewlines)
-    {
-        if (string.IsNullOrEmpty(source) || !source.Contains("\\"))
-            return source;
-
-        var sb = new StringBuilder(source.Length);
-
-        for (var i = 0; i < source.Length; i++)
-        {
-            var c = source[i];
-
-            // Check for Escape Character
-            if (c == '\\' && i + 1 < source.Length)
-            {
-                var next = source[i + 1];
-
-                // Handle Newlines (\n or \N)
-                if (handleNewlines && (next == 'n' || next == 'N'))
-                {
-                    sb.Append(Environment.NewLine);
-                    i++; // Skip the 'n'
-                }
-                // Handle Escaped Characters (\\, \, \;)
-                else if (next == '\\' || next == ',' || next == ';')
-                {
-                    sb.Append(next);
-                    i++; // Skip the escaped char
-                }
-                // Handle "Invalid" Escapes (e.g. \r or \z)
-                // RFC says: preserve the backslash if the escape is undefined.
-                else
-                {
-                    sb.Append(c);
-                }
-            }
-            else
-            {
-                sb.Append(c);
-            }
-        }
-
-        return sb.ToString();
+        return ValueUnescaper.Unescape(value, handleNewlines: true);
     }
 }

--- a/src/vCardLib/Deserialization/Utilities/ValueUnescaper.cs
+++ b/src/vCardLib/Deserialization/Utilities/ValueUnescaper.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace vCardLib.Deserialization.Utilities;
+
+internal static class ValueUnescaper
+{
+    /// <summary>
+    /// Inverse of <see cref="Serialization.Utilities.ValueEscaper.Escape"/>: decodes
+    /// \\, \, \; and \n / \N. Undefined escapes keep their backslash (RFC 6350 3.4).
+    /// </summary>
+    public static string Unescape(string source, bool handleNewlines = true)
+    {
+        if (string.IsNullOrEmpty(source) || !source.Contains("\\"))
+            return source;
+
+        var sb = new StringBuilder(source.Length);
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            var c = source[i];
+
+            if (c == '\\' && i + 1 < source.Length)
+            {
+                var next = source[i + 1];
+
+                if (handleNewlines && (next == 'n' || next == 'N'))
+                {
+                    sb.Append(Environment.NewLine);
+                    i++;
+                }
+                else if (next == '\\' || next == ',' || next == ';')
+                {
+                    sb.Append(next);
+                    i++;
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Splits on unescaped occurrences of <paramref name="delimiter"/> only, leaving escape
+    /// sequences intact for a later <see cref="Unescape"/> pass.
+    /// </summary>
+    public static string[] SplitUnescaped(string value, char delimiter)
+    {
+        var result = new List<string>();
+        var sb = new StringBuilder();
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+
+            if (c == '\\' && i + 1 < value.Length)
+            {
+                sb.Append(c);
+                sb.Append(value[i + 1]);
+                i++;
+            }
+            else if (c == delimiter)
+            {
+                result.Add(sb.ToString());
+                sb.Clear();
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        result.Add(sb.ToString());
+        return result.ToArray();
+    }
+}

--- a/src/vCardLib/Serialization/FieldSerializers/AddressFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/AddressFieldSerializer.cs
@@ -36,9 +36,13 @@ internal sealed class AddressFieldSerializer : IV2FieldSerializer<Address>, IV3F
 
         var parameters = SerializationHelpers.FormatParameters(version, types, null, extra);
 
+        // v2.1 has no backslash escaping mechanism.
+        var escape = version != vCardVersion.v2;
+        string E(string? component) => escape ? ValueEscaper.Escape(component) : component ?? string.Empty;
+
         var value = string.Join(FieldKeyConstants.MetadataDelimiter.ToString(),
-            data.PostOfficeBox, data.ApartmentOrSuiteNumber, data.StreetAddress, data.CityOrLocality,
-            data.StateOrProvinceOrRegion, data.PostalOrZipCode, data.Country);
+            E(data.PostOfficeBox), E(data.ApartmentOrSuiteNumber), E(data.StreetAddress), E(data.CityOrLocality),
+            E(data.StateOrProvinceOrRegion), E(data.PostalOrZipCode), E(data.Country));
 
         return $"{FieldKey}{parameters}{FieldKeyConstants.SectionDelimiter}{value}";
     }

--- a/src/vCardLib/Serialization/FieldSerializers/CategoriesFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/CategoriesFieldSerializer.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using vCardLib.Serialization.Interfaces;
+using vCardLib.Serialization.Utilities;
 
 namespace vCardLib.Serialization.FieldSerializers;
 
@@ -8,9 +10,14 @@ internal sealed class CategoriesFieldSerializer : IV2FieldSerializer<List<string
 {
     public string FieldKey => "CATEGORIES";
 
-    public string? Write(List<string> data)
+    // v2.1 has no backslash escaping mechanism.
+    string? IV2FieldSerializer<List<string>>.Write(List<string> data) => Format(data, escape: false);
+
+    public string? Write(List<string> data) => Format(data, escape: true);
+
+    private string Format(List<string> data, bool escape)
     {
-        var value = string.Join(",", data);
-        return $"{FieldKey}:{value}";
+        var items = escape ? data.Select(x => ValueEscaper.Escape(x)) : data;
+        return $"{FieldKey}:{string.Join(",", items)}";
     }
 }

--- a/src/vCardLib/Serialization/FieldSerializers/LabelFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/LabelFieldSerializer.cs
@@ -12,7 +12,14 @@ internal sealed class LabelFieldSerializer : IV2FieldSerializer<Label>, IV3Field
 {
     public string FieldKey => "LABEL";
 
-    public string? Write(Label data)
+    // v2.1 has no backslash escaping mechanism.
+    string? IV2FieldSerializer<Label>.Write(Label data) => Format(data, escape: false);
+
+    public string? Write(Label data) => Format(data, escape: true);
+
+    string? IV4FieldSerializer<Label>.Write(Label data) => null;
+
+    private string Format(Label data, bool escape)
     {
         var builder = new StringBuilder(FieldKey);
 
@@ -26,10 +33,8 @@ internal sealed class LabelFieldSerializer : IV2FieldSerializer<Label>, IV3Field
         }
 
         builder.Append(FieldKeyConstants.SectionDelimiter);
-        builder.Append(data.Text);
+        builder.Append(escape ? ValueEscaper.Escape(data.Text) : data.Text);
 
         return builder.ToString();
     }
-
-    string? IV4FieldSerializer<Label>.Write(Label data) => null;
 }

--- a/src/vCardLib/Serialization/FieldSerializers/NameFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/NameFieldSerializer.cs
@@ -1,6 +1,7 @@
-﻿using vCardLib.Constants;
+using vCardLib.Constants;
 using vCardLib.Models;
 using vCardLib.Serialization.Interfaces;
+using vCardLib.Serialization.Utilities;
 
 namespace vCardLib.Serialization.FieldSerializers;
 
@@ -8,6 +9,16 @@ internal sealed class NameFieldSerializer : IV2FieldSerializer<Name>, IV3FieldSe
 {
     public string FieldKey => "N";
 
-    public string Write(Name data) =>
-        $"{FieldKey}{FieldKeyConstants.SectionDelimiter}{data.FamilyName}{FieldKeyConstants.MetadataDelimiter}{data.GivenName}{FieldKeyConstants.MetadataDelimiter}{data.AdditionalNames}{FieldKeyConstants.MetadataDelimiter}{data.HonorificPrefix}{FieldKeyConstants.MetadataDelimiter}{data.HonorificSuffix}";
+    // v2.1 has no backslash escaping mechanism.
+    string IV2FieldSerializer<Name>.Write(Name data) => Format(data, escape: false);
+
+    public string Write(Name data) => Format(data, escape: true);
+
+    private string Format(Name data, bool escape)
+    {
+        string E(string? component) => escape ? ValueEscaper.Escape(component) : component ?? string.Empty;
+        var delimiter = FieldKeyConstants.MetadataDelimiter;
+
+        return $"{FieldKey}{FieldKeyConstants.SectionDelimiter}{E(data.FamilyName)}{delimiter}{E(data.GivenName)}{delimiter}{E(data.AdditionalNames)}{delimiter}{E(data.HonorificPrefix)}{delimiter}{E(data.HonorificSuffix)}";
+    }
 }

--- a/src/vCardLib/Serialization/FieldSerializers/OrganizationFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/OrganizationFieldSerializer.cs
@@ -1,7 +1,8 @@
-﻿using System.Text;
+using System.Text;
 using vCardLib.Constants;
 using vCardLib.Models;
 using vCardLib.Serialization.Interfaces;
+using vCardLib.Serialization.Utilities;
 
 namespace vCardLib.Serialization.FieldSerializers;
 
@@ -10,22 +11,29 @@ internal sealed class OrganizationFieldSerializer : IV2FieldSerializer<Organizat
 {
     public string FieldKey => "ORG";
 
-    public string Write(Organization data)
+    // v2.1 has no backslash escaping mechanism.
+    string IV2FieldSerializer<Organization>.Write(Organization data) => Format(data, escape: false);
+
+    public string Write(Organization data) => Format(data, escape: true);
+
+    private string Format(Organization data, bool escape)
     {
+        string E(string? component) => escape ? ValueEscaper.Escape(component) : component ?? string.Empty;
+
         var builder = new StringBuilder(FieldKey);
         builder.Append(FieldKeyConstants.SectionDelimiter);
-        builder.Append(data.Name);
+        builder.Append(E(data.Name));
 
         if (!string.IsNullOrWhiteSpace(data.PrimaryUnit))
         {
             builder.Append(FieldKeyConstants.MetadataDelimiter);
-            builder.Append(data.PrimaryUnit);
+            builder.Append(E(data.PrimaryUnit));
         }
 
         if (!string.IsNullOrWhiteSpace(data.SecondaryUnit))
         {
             builder.Append(FieldKeyConstants.MetadataDelimiter);
-            builder.Append(data.SecondaryUnit);
+            builder.Append(E(data.SecondaryUnit));
         }
 
         return builder.ToString();

--- a/src/vCardLib/Serialization/FieldSerializers/TextFieldSerializer.cs
+++ b/src/vCardLib/Serialization/FieldSerializers/TextFieldSerializer.cs
@@ -1,5 +1,6 @@
 using vCardLib.Constants;
 using vCardLib.Serialization.Interfaces;
+using vCardLib.Serialization.Utilities;
 
 namespace vCardLib.Serialization.FieldSerializers;
 
@@ -20,17 +21,5 @@ internal abstract class TextFieldSerializer : IV2FieldSerializer<string>, IV3Fie
     private string FormatField(string value)
         => $"{FieldKey}{FieldKeyConstants.SectionDelimiter}{value}";
 
-    private static string Escape(string data)
-    {
-        if (string.IsNullOrEmpty(data)) return data;
-
-        // RFC 2426 & RFC 6350: Escape \, ;, , and newlines.
-        return data
-            .Replace(@"\", @"\\")   // Must be first
-            .Replace(";", @"\;")
-            .Replace(",", @"\,")
-            .Replace("\r\n", @"\n") // Normalize Windows line endings
-            .Replace("\n", @"\n")
-            .Replace("\r", @"\n");  // Handle stray CRs
-    }
+    private static string Escape(string data) => ValueEscaper.Escape(data);
 }

--- a/src/vCardLib/Serialization/Utilities/ValueEscaper.cs
+++ b/src/vCardLib/Serialization/Utilities/ValueEscaper.cs
@@ -1,0 +1,21 @@
+namespace vCardLib.Serialization.Utilities;
+
+internal static class ValueEscaper
+{
+    /// <summary>
+    /// Escapes a single structured or list component per RFC 2426 &amp; RFC 6350 3.4.
+    /// Structural separators are added by the caller and must not be escaped here.
+    /// </summary>
+    public static string Escape(string? data)
+    {
+        if (string.IsNullOrEmpty(data)) return data ?? string.Empty;
+
+        return data!
+            .Replace(@"\", @"\\")   // Must be first
+            .Replace(";", @"\;")
+            .Replace(",", @"\,")
+            .Replace("\r\n", @"\n") // Normalize Windows line endings
+            .Replace("\n", @"\n")
+            .Replace("\r", @"\n");  // Handle stray CRs
+    }
+}


### PR DESCRIPTION
### Summary

The v3.0/v4.0 escape codec added in #75 was only wired into the single **TEXT** fields (`NOTE`, `TITLE`, `NICKNAME`, ...). The **structured** (`N`, `ORG`, `ADR`) and **list** (`CATEGORIES`) fields — plus `LABEL` — were never migrated, so a literal comma, semicolon, backslash or newline inside a component silently breaks a `Serialize` → `Deserialize` round trip.

Everything below is demonstrated with the library's own public API (`vCardSerializer` / `vCardDeserializer`); no external oracle is needed — `Deserialize(Serialize(card))` should equal `card`.

### Root cause

Two halves of the same omission, per field:

1. **Serialize** joins components with the raw delimiter and never escapes them:
   - `CATEGORIES` → `string.Join(",", data)`
   - `ORG` / `N` / `ADR` → raw `;`-joined components
2. **Deserialize** splits on the raw delimiter (ignoring `\,` / `\;`), and where it does unescape it calls **`Regex.Unescape`** — the .NET *regex* un-escaper, which is the wrong inverse. It decodes `\t`, `\n`, `\xNN`, `\uNNNN`, `\052`, ... and can drop a trailing backslash.

Round trips that corrupt on `master` today (v3 and v4):

| Field | In | Out |
|---|---|---|
| `CATEGORIES` | `["Food, Inc.", "Retail"]` | `["Food", "Inc.", "Retail"]` (2 → 3) |
| `ORG` name | `Ben & Jerry's; Homemade` | split into name + unit |
| `ORG` name | `C:\temp Corp` | `C:<TAB>emp Corp` (`Regex.Unescape` reads `\t`) |
| `ORG` name | `Acme\` | `Acme` (trailing `\` dropped) |
| `N` family | `Fam;ily,Name` | `Fam` (rest lost to component split) |

### Fix

Extract the escaper/unescaper #75 introduced into shared `ValueEscaper` / `ValueUnescaper` helpers (adding an escape-parity-aware splitter that only breaks on *unescaped* delimiters), and apply that one codec to `N`, `ORG`, `ADR`, `CATEGORIES` and `LABEL` on v3/v4:

- **Escape** per RFC 6350 §3.4 — within a component, escape `\ , ; ` and newlines. The structural separators (the `;` between `N`/`ADR` components, the `,` between `CATEGORIES` values) are added by the caller and are **not** escaped.
- **Unescape** is the exact inverse (`\\ \, \; \n`), with undefined escapes keeping their backslash. Every `Regex.Unescape` call is removed.
- Parameter values are left untouched — those are quoted, not backslash-escaped (RFC 6350 §3.3).
- **vCard 2.1** has no escaping mechanism, so its writer and reader keep passing values through verbatim on both sides (asserted separately).

### Tests

`StructuredFieldEscapingRoundTripTests` adds 21 cases: public round trips for each field over components containing `,` `;` `\` newline and `C:\temp`; the split truth table (unescaped `,` splits, `\,` is a literal comma, `\\,` is an escaped backslash then a separator); lenient decode of loose input (a raw `\t`/trailing `\` keeps its backslash instead of being regex-decoded); and no-regression checks that plain values still serialize byte-identically and v2.1 stays unescaped.

Full suite: **528 passing** (507 existing + 21 new), branch coverage 89.7%. Every new assertion was confirmed to fail on `master`.
